### PR TITLE
Refactor build commands for clarity and consistency

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,11 +48,11 @@ jobs:
                   echo "$changelog" >> $GITHUB_OUTPUT
                   echo "EOF" >> $GITHUB_OUTPUT
             - name: Build for Windows
-              run: GOOS=windows GOARCH=amd64 go build ./cmd/hdarrrr -o hdarrrr-windows-amd64.exe
+              run: GOOS=windows GOARCH=amd64 go build  -o hdarrrr-windows-amd64.exe ./cmd/hdarrrr
             - name: Build for Linux
-              run: GOOS=linux GOARCH=amd64 go build ./cmd/hdarrrr -o hdarrrr-linux-amd64
+              run: GOOS=linux GOARCH=amd64 go build -o hdarrrr-linux-amd64 ./cmd/hdarrrr
             - name: Build for macOS ARM64
-              run: GOOS=darwin GOARCH=arm64 go build ./cmd/hdarrrr -o hdarrrr-darwin-arm64
+              run: GOOS=darwin GOARCH=arm64 go build -o hdarrrr-darwin-arm64 ./cmd/hdarrrr
             - name: Create Release
               id: create_release
               uses: actions/create-release@v1


### PR DESCRIPTION
# Pull Request: Update Build Commands in Release Workflow

This pull request modifies the build commands in the GitHub Actions release workflow to improve clarity and maintainability of the build process.

### Why Changes Were Made
The changes clarify the order of arguments in the `go build` command by placing the output flag `-o` before the source path. This improves readability and conforms to common practices in CLI usage, potentially reducing confusion for developers who may read the script in the future.

### Changes Made
- Updated the build commands for Windows, Linux, and macOS to place the `-o` flag before the source path:
  - **Windows**: Changed from 
    ```bash
    GOOS=windows GOARCH=amd64 go build ./cmd/hdarrrr -o hdarrrr-windows-amd64.exe
    ``` 
    to 
    ```bash
    GOOS=windows GOARCH=amd64 go build -o hdarrrr-windows-amd64.exe ./cmd/hdarrrr
    ```
  - **Linux**: Changed from 
    ```bash
    GOOS=linux GOARCH=amd64 go build ./cmd/hdarrrr -o hdarrrr-linux-amd64
    ```
    to 
    ```bash
    GOOS=linux GOARCH=amd64 go build -o hdarrrr-linux-amd64 ./cmd/hdarrrr
    ```
  - **macOS ARM64**: Changed from 
    ```bash
    GOOS=darwin GOARCH=arm64 go build ./cmd/hdarrrr -o hdarrrr-darwin-arm64
    ``` 
    to 
    ```bash
    GOOS=darwin GOARCH=arm64 go build -o hdarrrr-darwin-arm64 ./cmd/hdarrrr
    ```

### Closed Issues
- None

These changes will not alter the functionality of the build process but will enhance the existing workflow's readability and maintainability.